### PR TITLE
Ensure that indented STDOUT output does not get interpreted as YAMLish

### DIFF
--- a/src/main/java/org/tap4j/parser/Tap13YamlParser.java
+++ b/src/main/java/org/tap4j/parser/Tap13YamlParser.java
@@ -53,7 +53,8 @@ protected TapElement lastParsedElement = null;
 	 * element with some multiline text.
 	 */
 	protected int currentIndentationLevel = -1;
-	
+
+	protected boolean currentlyInYAML = false;
 	/**
 	 * YAML parser and emitter.
 	 */
@@ -101,9 +102,15 @@ protected TapElement lastParsedElement = null;
 					// we are at the start of the meta tags, but we should ignore 
 					// the --- or ...
 					// TBD: check how snakeyaml can handle these tokens.
+					//
+					if ( tapLine.trim().equals("---") ){
+						this.currentlyInYAML = true;
+					}
+					if ( tapLine.trim().equals("...") ){
+						this.currentlyInYAML = false;
+					}
 					
 					this.appendTapLineToDiagnosticBuffer( tapLine );
-					
 					return; // NOPMD by Bruno on 12/01/11 07:47
 				}
 				
@@ -308,12 +315,14 @@ protected TapElement lastParsedElement = null;
 	 */
 	private void appendTapLineToDiagnosticBuffer( String diagnosticLine )
 	{
-		if ( diagnosticLine.trim().equals("---") || diagnosticLine.trim().equals("...") )
-		{
+		if ( diagnosticLine.trim().equals("---") || diagnosticLine.trim().equals("...")  ){
 			return;
 		}
-		diagnosticBuffer.append( diagnosticLine );
-		diagnosticBuffer.append( '\n' );
+		
+		if ( this.currentlyInYAML ) {
+			diagnosticBuffer.append( diagnosticLine );
+			diagnosticBuffer.append( '\n' );
+		}
 	}
 
 	/**

--- a/src/test/java/org/tap4j/consumer/TestTap13YamlConsumer.java
+++ b/src/test/java/org/tap4j/consumer/TestTap13YamlConsumer.java
@@ -128,5 +128,39 @@ public class TestTap13YamlConsumer
 			Assert.fail( e.getMessage());
 		}
 	}
+
+	@Test
+	public void test3()
+	{
+		try 
+		{
+			TestSet testSet = consumer.load( new File(TestTap13YamlConsumer.class.getResource("/input_tap13/org.tap4j.testng.konobi.tap").getFile()) );
+			
+			Assert.assertNotNull( testSet.getPlan() );
+			
+			Assert.assertTrue ( testSet.getPlan().getInitialTestNumber() == 1 );
+			
+			Assert.assertTrue( testSet.getPlan().getLastTestNumber() == 1 );
+			
+			Assert.assertTrue( testSet.getTestResults().size() == 1 );
+			
+			Assert.assertTrue ( testSet.getTestResult(1).getStatus() == StatusValues.NOT_OK );
+			
+			Assert.assertNotNull ( testSet.getTestResult(1).getDiagnostic() );
+			
+			Map<String, Object> diagnostic = testSet.getTestResult(1).getDiagnostic();
+			
+			Assert.assertNotNull( diagnostic );
+			
+			Assert.assertEquals( diagnostic.get("file"), "org.tap4j.testng.konobi.java" );
+			
+			Assert.assertNotNull( diagnostic.get("stack") );
+			
+		} 
+		catch (TapConsumerException e) 
+		{
+			Assert.fail( e.getMessage());
+		}
+	}
 	
 }

--- a/src/test/resources/input_tap13/org.tap4j.testng.konobi.tap
+++ b/src/test/resources/input_tap13/org.tap4j.testng.konobi.tap
@@ -1,0 +1,32 @@
+not ok 1
+  ---
+      file: org.tap4j.testng.konobi.java
+      description: null
+      wanted: 'true'
+      found: 'false'
+      extensions:
+        Start: 1291572796343
+        End: 1291572797031
+        Took: 688
+        Parameters: ''
+        Attributes: {}
+        Files:
+          File:
+            File-Size: 104192
+            File-Type: image/jpeg
+            File-Description: Selenium Test testBuscaBrunoKinoshita
+            File-Name: testBuscaBrunoKinoshita.jpg
+            File-Title: testBuscaBrunoKinoshita.jpg
+            File-Location: C:\dev\java\hudson_workspace\SampleTestNGSelenium\tap\testBuscaBrunoKinoshita.jpg
+      stack:
+        - Hello
+        - "Is there anyone out there?"
+        - |
+          Is this what I'm looking for?
+      test: good
+  ...
+this: { thing: 'here',
+  breaks: '=0(',
+
+1..1
+# lets see...


### PR DESCRIPTION
We've been seeing this with JSON in STDOUT output in TAP.

Would be great to get a spin of this along with the tap-plugin for jenkins.
