### PR TITLE
Clear up handling of character encodings in Consumer and Producer.

### DIFF
--- a/tap4j/src/main/java/org/tap4j/consumer/TapConsumer.java
+++ b/tap4j/src/main/java/org/tap4j/consumer/TapConsumer.java
@@ -24,6 +24,7 @@
 package org.tap4j.consumer;
 
 import java.io.File;
+import java.io.InputStreamReader; // referenced in JavaDoc
 
 import org.tap4j.model.TestSet;
 import org.tap4j.parser.Parser;
@@ -38,11 +39,29 @@ public interface TapConsumer {
     /**
      * Parses a TAP File.
      *
+     * Note: this method only works if the {@code TapConsumer} was constructed
+     * with an assumed character set encoding, <em>and</em> {@code file} really
+     * is encoded in that assumed encoding.
+     *
+     * For a more flexible approach, the caller (who should know best about the
+     * encoding of any given input file) should have already
+     * wrapped the file in an {@link InputStreamReader}, and should pass that to
+     * {@link #load(Readable)}.
+     *
      * @param file TAP File.
      * @return TestSet
      * @throws TapConsumerException
      */
     TestSet load(File file);
+
+    /**
+     * Parses a TAP Stream.
+     *
+     * @param tapStream TAP Stream
+     * @return TestSet
+     * @throws TapConsumerException
+     */
+    TestSet load(Readable tapStream);
 
     /**
      * Parses a TAP Stream.

--- a/tap4j/src/main/java/org/tap4j/consumer/TapConsumerImpl.java
+++ b/tap4j/src/main/java/org/tap4j/consumer/TapConsumerImpl.java
@@ -68,6 +68,7 @@ public class TapConsumerImpl implements TapConsumer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public TestSet getTestSet() {
         return this.testSet;
     }
@@ -75,6 +76,7 @@ public class TapConsumerImpl implements TapConsumer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public TestSet load(File file) {
         try {
             this.testSet = this.parser.parseFile(file);
@@ -88,6 +90,21 @@ public class TapConsumerImpl implements TapConsumer {
     /**
      * {@inheritDoc}
      */
+    @Override
+    public TestSet load(Readable tapStream) {
+        try {
+            this.testSet = this.parser.parseTapStream(tapStream);
+        } catch (ParserException e) {
+            throw new TapConsumerException("Failed to parse TAP Stream "
+                                            + tapStream + ": " + e.getMessage(), e);
+        }
+        return this.testSet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public TestSet load(String tapStream) {
         try {
             this.testSet = this.parser.parseTapStream(tapStream);
@@ -101,6 +118,7 @@ public class TapConsumerImpl implements TapConsumer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Parser getParser() {
         return this.parser;
     }

--- a/tap4j/src/main/java/org/tap4j/parser/Parser.java
+++ b/tap4j/src/main/java/org/tap4j/parser/Parser.java
@@ -24,6 +24,7 @@
 package org.tap4j.parser;
 
 import java.io.File;
+import java.io.InputStreamReader; // referenced in JavaDoc
 
 import org.tap4j.model.TestSet;
 
@@ -40,10 +41,25 @@ public interface Parser {
      * @param tapStream TAP Stream
      * @return Test Set
      */
+    TestSet parseTapStream(Readable tapStream);
+
+    /**
+     * Parses a TAP Stream.
+     *
+     * @param tapStream TAP Stream
+     * @return Test Set
+     */
     TestSet parseTapStream(String tapStream);
 
     /**
      * Parses a TAP File.
+     *
+     * Note: this method must only be used if this Parser was created with
+     * a specified character set encoding <em>and</em> {@code tapFile} is
+     * known to be written in that same encoding. Otherwise, the caller (which
+     * probably knows best the file's encoding) can wrap the file in an
+     * {@link InputStreamReader} and pass that to
+     * {@link #parseTapStream(Readable) parseTapStream(Readable)}.
      *
      * @param tapFile TAP File
      * @return Test Set

--- a/tap4j/src/main/java/org/tap4j/producer/Producer.java
+++ b/tap4j/src/main/java/org/tap4j/producer/Producer.java
@@ -57,6 +57,14 @@ public interface Producer {
     /**
      * Writes the TAP Stream into an output File.
      *
+     * This will choose an encoding for the output written to the file, using
+     * the following rules. If this Producer's {@code Representer} is a
+     * {@code Tap13Representer}, the chosen encoding will be taken from its
+     * {@code Charset} option. In any other case, the chosen encoding will be
+     * the system's default encoding. If that is not the correct encoding for
+     * the file, the caller should wrap the file in a {@link Writer} for the
+     * correct encoding, and pass that to {@link #dump(TestSet,Writer)}.
+     *
      * @param testSet TestSet
      * @param output Output File
      * @throws ProducerException


### PR DESCRIPTION
What Consumer and Parser were doing was a little bit inside-out. The Parser constructors want an encoding, even though the only time the Parser should need it is when reading from something like a raw File that isn't already decoded; meanwhile, if you parsed from a String (something that already _is_ decoded), it would actually get _encoded_ into that constructor-specified encoding, just to get _decoded_ again and then parsed.

I added to the interface a method that takes any generic `Readable`, which is really the fundamental method for input that doesn't need any decoding but might be coming to you in a stream. Working from a `String` is a special case because it has to be all in memory at once. If you have a method that takes `Readable` it's easy to pass a `String` in (just put `CharBuffer.wrap()` around it), but the other way doesn't work ... if there's only a method that takes a `String`, there is no easy way to feed it a stream short of slurping it up into RAM first.

So now the method that takes `String` does exactly call `CharBuffer.wrap` on it and pass it to the method taking a `Readable`. The methods applying to a raw `File` have more JavaDoc explaining the encoding assumptions, since those matter to somebody calling them. And I've used `java.nio.charset.CharsetDecoder` explicitly so it will make sure the input is valid in the assumed encoding and throw exceptions otherwise. The various other Java API methods to set up decoding result in the older Java default behavior of silently dropping or changing characters, which seems not just what a testing tool ought to be doing.

On the producer side, there was already a method taking a generic `Writer` so I didn't add anything, except for more JavaDoc again explaining the encoding assumptions for the method taking a `File`. And again I used the `java.nio.charset.CharsetEncoder` so it will throw exceptions if the result isn't encodable in the chosen encoding, instead of doing the old Java silently-lose thing.