### PR TITLE
Correct subtest placement

### DIFF
--- a/tap4j/src/main/java/org/tap4j/model/Patterns.java
+++ b/tap4j/src/main/java/org/tap4j/model/Patterns.java
@@ -42,17 +42,17 @@ public final class Patterns {
     /**
      * TAP Text Regex.
      */
-    static final String REGEX_TEXT = "((\\s|\\t)*)(.*)";
+    static final String REGEX_TEXT = "(\\s*)(.*)";
 
     /**
      * TAP Header Regex.
      */
-    static final String REGEX_HEADER = "((\\s|\\t)*)?TAP\\s*version\\s*(\\d+)\\s*(#\\s*(.*))?";
+    static final String REGEX_HEADER = "(\\s*)TAP\\s*version\\s*(\\d+)\\s*(#\\s*(.*))?";
 
     /**
      * TAP Plan Regex.
      */
-    static final String REGEX_PLAN = "((\\s|\\t)*)?(\\d+)(\\.{2})(\\d+)"
+    static final String REGEX_PLAN = "(\\s*)(\\d+)(\\.{2})(\\d+)"
             + "\\s*(#\\s*(SKIP|skip)\\s*([^#]+))?\\s*(#\\s*(.*))?";
 
     /**
@@ -64,17 +64,17 @@ public final class Patterns {
     /**
      * TAP Bail Out! Regex.
      */
-    static final String REGEX_BAIL_OUT = "((\\s|\\t)*)?Bail out!\\s*([^#]+)?\\s*(#\\s*(.*))?";
+    static final String REGEX_BAIL_OUT = "(\\s*)Bail out!\\s*([^#]+)?\\s*(#\\s*(.*))?";
 
     /**
      * TAP Comment Regex.
      */
-    static final String REGEX_COMMENT = "((\\s|\\t)*)?#\\s*(.*)";
+    static final String REGEX_COMMENT = "(\\s*)#\\s*(.*)";
 
     /**
      * TAP Footer Regex.
      */
-    static final String REGEX_FOOTER = "((\\s|\\t)*)?TAP\\s*([^#]*)?\\s*(#\\s*(.*))?";
+    static final String REGEX_FOOTER = "(\\s*)TAP\\s*([^#]*)?\\s*(#\\s*(.*))?";
 
     /* -- Patterns -- */
 

--- a/tap4j/src/main/java/org/tap4j/model/Patterns.java
+++ b/tap4j/src/main/java/org/tap4j/model/Patterns.java
@@ -58,7 +58,7 @@ public final class Patterns {
     /**
      * TAP Test Result Regex.
      */
-    static final String REGEX_TEST_RESULT = "((\\s|\\t)*)?(ok|not ok)\\s*(\\d*)\\s*([^#]*)?\\s*"
+    static final String REGEX_TEST_RESULT = "(\\s*)(ok|not ok)\\s*(\\d*)\\s*([^#]*)?\\s*"
             + "(#\\s*(SKIP|skip|TODO|todo)\\s*([^#]*))?\\s*(#\\s*(.*))?";
 
     /**

--- a/tap4j/src/main/java/org/tap4j/model/TapElementFactory.java
+++ b/tap4j/src/main/java/org/tap4j/model/TapElementFactory.java
@@ -115,22 +115,22 @@ public final class TapElementFactory {
 
         m = Patterns.TEST_RESULT_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            String testNumberText = m.group(4);
+            String testNumberText = m.group(3);
             int testNumber = 0;
-            if (testNumberText != null && testNumberText.trim().equals("") == false) {
+            if (testNumberText != null && !testNumberText.trim().equals("")) {
                 testNumber = Integer.parseInt(testNumberText);
             }
-            TestResult testResult = new TestResult(StatusValues.get(m.group(3)), testNumber);
-            String comment = m.group(10);
+            TestResult testResult = new TestResult(StatusValues.get(m.group(2)), testNumber);
+            String comment = m.group(9);
             if (comment != null && comment.trim().length() > 0) {
                 final Comment c = new Comment(comment, true);
                 testResult.setComment(c);
                 testResult.addComment(c);
             }
-            testResult.setDescription(m.group(5));
-            DirectiveValues directive = DirectiveValues.get(m.group(7));
+            testResult.setDescription(m.group(4));
+            DirectiveValues directive = DirectiveValues.get(m.group(6));
             if (directive != null) {
-                testResult.setDirective(new Directive(directive, m.group(8)));
+                testResult.setDirective(new Directive(directive, m.group(7)));
             }
             testResult.indentation = m.group(1).length();
             return testResult;

--- a/tap4j/src/main/java/org/tap4j/model/TapElementFactory.java
+++ b/tap4j/src/main/java/org/tap4j/model/TapElementFactory.java
@@ -71,33 +71,33 @@ public final class TapElementFactory {
 
         m = Patterns.COMMENT_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            Comment comment = new Comment(m.group(3), false);
+            Comment comment = new Comment(m.group(2), false);
             comment.indentation = m.group(1).length();
             return comment;
         }
 
         m = Patterns.HEADER_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            Header header = new Header(Integer.parseInt(m.group(3)));
+            Header header = new Header(Integer.parseInt(m.group(2)));
             header.indentation = m.group(1).length();
-            addComment(header, m.group(5));
+            addComment(header, m.group(4));
             return header;
         }
 
         m = Patterns.FOOTER_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            Footer footer = new Footer(m.group(3));
-            addComment(footer, m.group(5));
+            Footer footer = new Footer(m.group(2));
+            addComment(footer, m.group(4));
             footer.indentation = m.group(1).length();
             return footer;
         }
 
         m = Patterns.PLAN_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            String skip = m.group(8);
-            String comment = m.group(10);
+            String skip = m.group(7);
+            String comment = m.group(9);
             SkipPlan skipPlan = skip != null && skip.trim().length() > 0 ? new SkipPlan(skip) : null;
-            Plan plan = new Plan(Integer.parseInt(m.group(3)), Integer.parseInt(m.group(5)), skipPlan);
+            Plan plan = new Plan(Integer.parseInt(m.group(2)), Integer.parseInt(m.group(4)), skipPlan);
             addComment(plan, comment);
             plan.indentation = m.group(1).length();
             return plan;
@@ -105,8 +105,8 @@ public final class TapElementFactory {
 
         m = Patterns.BAIL_OUT_PATTERN.matcher(tapLine);
         if (m.matches()) {
-            String reason = m.group(3);
-            String comment = m.group(5);
+            String reason = m.group(2);
+            String comment = m.group(4);
             BailOut bailOut = new BailOut(reason);
             addComment(bailOut, comment);
             bailOut.indentation = m.group(1).length();

--- a/tap4j/src/main/java/org/tap4j/parser/StreamStatus.java
+++ b/tap4j/src/main/java/org/tap4j/parser/StreamStatus.java
@@ -82,17 +82,6 @@ public class StreamStatus {
     private final TestSet testSet = new TestSet();
 
     /**
-     * In case sub-tests could not have been attached to parent (as the sub-tests came first)
-     * we need to make sure we make the link as the parent test comes.
-     */
-    protected boolean attachedToParent;
-
-    /**
-     * Stream status test set.
-     */
-    protected TestSet looseSubtests; 
-
-    /**
      * Default constructor.
      */
     public StreamStatus() {

--- a/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
+++ b/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
@@ -32,22 +32,11 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.Stack;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.tap4j.model.BailOut;
-import org.tap4j.model.Comment;
-import org.tap4j.model.Footer;
-import org.tap4j.model.Header;
-import org.tap4j.model.Plan;
-import org.tap4j.model.TapElement;
-import org.tap4j.model.TapElementFactory;
-import org.tap4j.model.TestResult;
-import org.tap4j.model.TestSet;
-import org.tap4j.model.Text;
+import org.tap4j.model.*;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -72,7 +61,7 @@ public class Tap13Parser implements Parser {
      * Stack of stream status information bags. Every bag stores state of the parser
      * related to certain indentation level. This is to support subtest feature.
      */
-    private Stack<StreamStatus> states = new Stack<StreamStatus>();
+    private Stack<StreamStatus> states = new Stack<>();
 
     /**
      * The current state.
@@ -96,6 +85,11 @@ public class Tap13Parser implements Parser {
      * Enable subtests.
      */
     private boolean enableSubtests = true;
+
+    /**
+     * A stack that holds subtests for which we don't know exact parent yet.
+     */
+    private Stack<StreamStatus> subStack = new Stack<>();
 
     /**
      * Parser Constructor.
@@ -280,31 +274,24 @@ public class Tap13Parser implements Parser {
             baseIndentation = indentation;
         }
 
-        if (indentation != state.getIndentationLevel()) { // indentation changed
+        StreamStatus prevState = null;
+        if (indentation != state.getIndentationLevel() && enableSubtests) { // indentation changed
 
             if (indentation > state.getIndentationLevel()) {
-                StreamStatus parentState = state;
+                int prevIndent = state.getIndentationLevel();
                 pushState(indentation); // make room for children
-
-                TapElement lastParentElement = parentState.getLastParsedElement();
-                if (lastParentElement instanceof TestResult) {
-                    final TestResult lastTestResult = (TestResult) lastParentElement;
-                    // whatever test set comes should be attached to parent
-                    if (lastTestResult.getSubtest() == null && this.enableSubtests) {
-                        lastTestResult.setSubtest(state.getTestSet());
-                        state.attachedToParent = true;
-                    }
-                }
+                if (indentation - prevIndent > 4)
+                    subStack.push(state);
             } else {
                 // going down
-                do {
-                    StreamStatus prevState = state;
+                if (states.peek().getIndentationLevel() == indentation) {
+                    prevState = state;
                     state = states.pop();
-                    if (!prevState.attachedToParent && this.enableSubtests) {
-                        state.looseSubtests = prevState.getTestSet();
-                    }
-                    // there could be more than one level diff
-                } while (indentation < state.getIndentationLevel());
+                } else {
+                    state = new StreamStatus();
+                    state.setIndentationLevel(indentation);
+                    subStack.push(state);
+                }
             }
         }
 
@@ -354,9 +341,21 @@ public class Tap13Parser implements Parser {
             }
 
             state.getTestSet().addTestResult(testResult);
-            if (state.looseSubtests != null && this.enableSubtests) {
-                testResult.setSubtest(state.looseSubtests);
-                state.looseSubtests = null;
+
+            if (prevState != null && enableSubtests) {
+                state.getTestSet().getTestResults().get(
+                        state.getTestSet().getNumberOfTestResults() - 1)
+                        .setSubtest(prevState.getTestSet());
+            }
+
+            if (indentation == 0 && enableSubtests) {
+                TestResult currLast = state.getTestSet().getTestResults().get(
+                            state.getTestSet().getNumberOfTestResults() - 1);
+                while (!subStack.empty()) {
+                    StreamStatus nextLevel = subStack.pop();
+                    currLast.setSubtest(nextLevel.getTestSet());
+                    currLast = nextLevel.getTestSet().getTestResults().get(0);
+                }
             }
 
         } else if (tapElement instanceof Footer) {

--- a/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
+++ b/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
@@ -23,6 +23,18 @@
  */
 package org.tap4j.parser;
 
+import org.tap4j.model.BailOut;
+import org.tap4j.model.Comment;
+import org.tap4j.model.Footer;
+import org.tap4j.model.Header;
+import org.tap4j.model.Plan;
+import org.tap4j.model.TapElement;
+import org.tap4j.model.TapElementFactory;
+import org.tap4j.model.TestResult;
+import org.tap4j.model.TestSet;
+import org.tap4j.model.Text;
+import org.yaml.snakeyaml.Yaml;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -32,12 +44,11 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.*;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.tap4j.model.*;
-import org.yaml.snakeyaml.Yaml;
 
 /**
  * TAP 13 parser.

--- a/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
+++ b/tap4j/src/main/java/org/tap4j/parser/Tap13Parser.java
@@ -343,7 +343,7 @@ public class Tap13Parser implements Parser {
 
             final TestResult testResult = (TestResult) tapElement;
             if (testResult.getTestNumber() == 0) {
-                if (state.getTestSet().getPlan() != null && state.isPlanBeforeTestResult() == false) {
+                if (state.getTestSet().getPlan() != null && !state.isPlanBeforeTestResult()) {
                     return; // done testing mark
                 }
                 if (state.getTestSet().getPlan() != null &&

--- a/tap4j/src/main/java/org/tap4j/representer/Tap13Representer.java
+++ b/tap4j/src/main/java/org/tap4j/representer/Tap13Representer.java
@@ -127,6 +127,13 @@ public class Tap13Representer implements Representer {
      * @param testResult TAP test result
      */
     protected void printTestResult(PrintWriter pw, TestResult testResult) {
+        if (testResult.getSubtest() != null) {
+            int indent = this.options.getIndent();
+            int spaces = this.options.getSpaces();
+            this.options.setIndent(indent + spaces);
+            pw.append(this.representData(testResult.getSubtest()));
+            this.options.setIndent(indent);
+        }
         printFiller(pw);
         pw.append(testResult.getStatus().toString());
         pw.append(' ' + Integer.toString(testResult.getTestNumber()));
@@ -155,13 +162,6 @@ public class Tap13Representer implements Representer {
         }
         printDiagnostic(pw, testResult);
         pw.append(LINE_SEPARATOR);
-        if (testResult.getSubtest() != null) {
-            int indent = this.options.getIndent();
-            int spaces = this.options.getSpaces();
-            this.options.setIndent(indent + spaces);
-            pw.append(this.representData(testResult.getSubtest()));
-            this.options.setIndent(indent);
-        }
     }
 
     /**

--- a/tap4j/src/test/java/org/tap4j/consumer/subtestOrder/TestSubtestOrder.java
+++ b/tap4j/src/test/java/org/tap4j/consumer/subtestOrder/TestSubtestOrder.java
@@ -21,55 +21,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.tap4j.consumer.issue3504508;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
+package org.tap4j.consumer.subtestOrder;
 
 import org.junit.Test;
 import org.tap4j.BaseTapTest;
 import org.tap4j.consumer.TapConsumer;
 import org.tap4j.consumer.TapConsumerFactory;
 import org.tap4j.model.TestSet;
-import org.tap4j.parser.Tap13Parser;
-import org.tap4j.producer.Producer;
-import org.tap4j.producer.TapProducer;
+import org.tap4j.producer.TapProducerFactory;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for subtests.
+ * Tests for correct subtests order.
  *
  * @since 0.1
  */
-public class TestIssue3504508 extends BaseTapTest {
-
-    @Test
-    public void testTapConsumer() {
-        final TestSet testSet = getTestSet(new Tap13Parser(/* enable subtests*/ true), "/org/tap4j/consumer/issue3504508/sample.tap");
-        assertTrue(testSet.getTestResult(1).getSubtest() == null);
-        assertTrue(testSet.getTestResult(2).getSubtest()
-                .getTestResult(2).getSubtest() != null);
-        assertTrue(testSet.getTestResults().size() == 3);
-    }
-
+public class TestSubtestOrder extends BaseTapTest {
     @Test
     public void testProducingSubtests() {
-        final String expected = "1..3\n"
-                + "ok 1 - First test\n"
-                + "    1..2\n"
-                + "    ok 1 - This is a subtest\n"
-                + "        1..2\n"
-                + "        ok 1 - This is a subtest\n"
-                + "        ok 2 - So is this\n"
-                + "    ok 2 - So is this\n"
-                + "ok 2 - An example subtest\n"
-                + "ok 3 - Third test\n";
         final TapConsumer consumer = TapConsumerFactory.makeTap13YamlConsumer();
-        final TestSet testSet = consumer.load(new File(TestIssue3504508.class
-                .getResource("/org/tap4j/consumer/issue3504508/sample.tap").getFile()));
-        final Producer producer = new TapProducer();
-        assertEquals(expected, producer.dump(testSet));
+        final TestSet testSet = consumer.load(new File(TestSubtestOrder.class
+                .getResource("/org/tap4j/consumer/subtestOrder/subtest.tap").getFile()));
+        String expected = "1..2\n"
+                + "ok 1 - First test\n"
+                + "    1..1\n"
+                + "        1..1\n"
+                + "        ok 1 - Internal subtest subtest\n"
+                + "    ok 1 - Internal subtest\n"
+                + "ok 2 - Some subtest\n";
+        assertEquals(expected, TapProducerFactory.makeTap13Producer().dump(testSet));
+        assertNotNull(testSet.getTestResult(2).getSubtest());
+        assertNotNull(testSet.getTestResult(2).getSubtest()
+                .getTestResult(1).getSubtest());
     }
 
 }

--- a/tap4j/src/test/resources/org/tap4j/consumer/issue3504508/sample.tap
+++ b/tap4j/src/test/resources/org/tap4j/consumer/issue3504508/sample.tap
@@ -1,10 +1,10 @@
-  1..3
-  ok 1 - First test
-      1..2
-      ok 1 - This is a subtest
-      ok 2 - So is this
+1..3
+ok 1 - First test
+    1..2
+    ok 1 - This is a subtest
         1..2
         ok 1 - This is a subtest
         ok 2 - So is this
-  ok 2 - An example subtest
-  ok 3 - Third test
+    ok 2 - So is this
+ok 2 - An example subtest
+ok 3 - Third test

--- a/tap4j/src/test/resources/org/tap4j/consumer/subtestOrder/subtest.tap
+++ b/tap4j/src/test/resources/org/tap4j/consumer/subtestOrder/subtest.tap
@@ -1,0 +1,7 @@
+ok 1 - First test
+        ok 1 - Internal subtest subtest
+        1..1
+    ok 1 - Internal subtest
+    1..1
+ok 2 - Some subtest
+1..2

--- a/tap4j/src/test/resources/org/tap4j/parser/issueGitHub17/issue-17-tap-stream.tap
+++ b/tap4j/src/test/resources/org/tap4j/parser/issueGitHub17/issue-17-tap-stream.tap
@@ -1,10 +1,6 @@
 TAP version 13
 1..2
   ---
-    datetime: 20100101T000000
-  ...
-ok 1 - someDummyTest
-  ---
     datetime: 20100101T000002
   ...
   1..5
@@ -13,9 +9,13 @@ ok 1 - someDummyTest
   ok
   ok
   ok
-ok 2 - anotherDummyTest
+ok 1 - someDummyTest
   ---
     datetime: 20100101T000005
   ...
   1..1
   ok
+ok 2 - anotherDummyTest
+---
+  datetime: 20100101T000000
+...


### PR DESCRIPTION
This PR enables subtest parsing with appending it to correct TestResult node, discussed at https://github.com/tupilabs/tap4j/issues/48.
It passes all tests with minor tweaks to the suite regarding cases where test data was incorrect(judging by Perl-style subtests, of course). It closes the issue.

On the other hand, I can see that breakage of backward compatibility can harm a lot, so we can probably enable it by a flag or the PR can be just rejected.